### PR TITLE
Removing hardcoded database name for item

### DIFF
--- a/Source/Transitus.Rainbow/Transitus.Rainbow/Sync/RainbowItemDeserializer.cs
+++ b/Source/Transitus.Rainbow/Transitus.Rainbow/Sync/RainbowItemDeserializer.cs
@@ -1,32 +1,32 @@
 ﻿namespace Transitus.Rainbow.Sync
 {
-	using System.IO;
-	using System.Xml;
+    using System.IO;
+    using System.Xml;
 
-	using global::Rainbow.Filtering;
-	using global::Rainbow.Formatting;
-	using global::Rainbow.Storage.Yaml;
+    using global::Rainbow.Filtering;
+    using global::Rainbow.Formatting;
+    using global::Rainbow.Storage.Yaml;
 
-	using Sitecore.IO;
+    using Sitecore.IO;
 
-	public class RainbowItemDeserializer : IFileDeserializer
-	{
-		protected readonly ISerializationFormatter SerializationFormatter;
+    public class RainbowItemDeserializer : IFileDeserializer
+    {
+        protected readonly ISerializationFormatter SerializationFormatter;
 
-		public RainbowItemDeserializer()
-		{
-			// TODO: See if we can move this to a config file, rather than hard coding it here.
-			const string xmlNodeString = @"
+        public RainbowItemDeserializer()
+        {
+            // TODO: See if we can move this to a config file, rather than hard coding it here.
+            const string xmlNodeString = @"
 				<serializationFormatter type=""Rainbow.Storage.Yaml.YamlSerializationFormatter, Rainbow.Storage.Yaml"" singleInstance=""true"">
 					<fieldFormatter type=""Rainbow.Formatting.FieldFormatters.MultilistFormatter, Rainbow"" />
                     <fieldFormatter type=""Rainbow.Formatting.FieldFormatters.XmlFieldFormatter, Rainbow"" />
                   </serializationFormatter >
 			";
-			var doc = new XmlDocument();
-			doc.LoadXml(xmlNodeString);
+            var doc = new XmlDocument();
+            doc.LoadXml(xmlNodeString);
 
-			// TODO: See if we can move this to a config file, rather than hard coding it here.
-			const string fieldFilterXmlString = @"
+            // TODO: See if we can move this to a config file, rather than hard coding it here.
+            const string fieldFilterXmlString = @"
 				<fieldFilter type=""Rainbow.Filtering.ConfigurationFieldFilter, Rainbow"" singleInstance=""true"">
 					<exclude fieldID=""{B1E16562-F3F9-4DDD-84CA-6E099950ECC0}"" note=""'Last run' field on Schedule template (used to register tasks)"" />
 					<exclude fieldID=""{52807595-0F8F-4B20-8D2A-CB71D28C6103}"" note=""'__Owner' field on Standard Template"" />
@@ -37,34 +37,33 @@
 					<exclude fieldID=""{001DD393-96C5-490B-924A-B0F25CD9EFD8}"" note=""'__Lock' field on Standard Template"" />
 				</fieldFilter>
 			";
-			var fieldFilterXml = new XmlDocument();
-			fieldFilterXml.LoadXml(fieldFilterXmlString);
+            var fieldFilterXml = new XmlDocument();
+            fieldFilterXml.LoadXml(fieldFilterXmlString);
 
-			this.SerializationFormatter = new YamlSerializationFormatter(doc, new ConfigurationFieldFilter(fieldFilterXml));
-		}
+            this.SerializationFormatter = new YamlSerializationFormatter(doc, new ConfigurationFieldFilter(fieldFilterXml));
+        }
 
-		public IItem Deserialize(string filePath)
-		{
-			var syncItem = this.ReadItem(filePath);
+        public IItem Deserialize(string filePath)
+        {
+            var syncItem = this.ReadItem(filePath);
 
-			return syncItem;
-		}
+            return syncItem;
+        }
 
-		public string ItemFileExtension => ".yml";
+        public string ItemFileExtension => ".yml";
 
         public IItem ReadItem(string filePath)
         {
-			var file = new FileInfo(filePath);
-	
-			lock (FileUtil.GetFileLock(file.FullName))
-			{
-				using (var reader = file.OpenRead())
-				{
-					var readItem = this.SerializationFormatter.ReadSerializedItem(reader, filePath);
-					readItem.DatabaseName = "master";
-					return new RainbowItem(readItem);					
-				}
-			}
+            var file = new FileInfo(filePath);
+
+            lock (FileUtil.GetFileLock(file.FullName))
+            {
+                using (var reader = file.OpenRead())
+                {
+                    var readItem = this.SerializationFormatter.ReadSerializedItem(reader, filePath);
+                    return new RainbowItem(readItem);
+                }
+            }
         }
-	}
+    }
 }


### PR DESCRIPTION
Remove the code that hardcode the deserialized item database name to be "master". The item could be serialized from core or other custom databases.